### PR TITLE
Prefer triple equals in statements

### DIFF
--- a/source/content_script.js
+++ b/source/content_script.js
@@ -77,7 +77,7 @@ function handleText(textNode) {
 		let curColor = colors[i];
 		let re = `\\b(${curColor})\\b`; //need to double-escape the \b
 		let regex = new RegExp(re, 'gi');
-		if(disabledNames().indexOf(curColor) == -1 && regex.test(textNode.nodeValue.toLowerCase())){
+		if(disabledNames().indexOf(curColor) === -1 && regex.test(textNode.nodeValue.toLowerCase())){
 			containsColor = true;
 			break;
 		}
@@ -99,7 +99,7 @@ function appendColorsToName(text, fontSize){
 	colorNames().forEach((name, index, enumerable) => {
 		let re = `\\b(${name})\\b`; //need to double-escape the \b
 		let regex = new RegExp(re, 'gi'); //case-insensitive so we don't need to change capitalization
-		if(text && disabledNames().indexOf(name) == -1){
+		if(text && disabledNames().indexOf(name) === -1){
 			text = text.replace(regex, `$1 ${getColorsFromName(name, fontSize)}`);
 		}
 	});

--- a/source/popup.js
+++ b/source/popup.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
   toggleButton.onclick = function(element) {
     let input = document.getElementById('mtgGuildColorsInput');
-    let currentState = input.value == 'true' || input.value == true ? true : false;
+    let currentState = input.value === 'true' || input.value === true;
     console.log('Current state is: ', currentState);
 
     let newState = !currentState;


### PR DESCRIPTION
JavaScript has some weird behavior when using `==` instead of `===`. Doesn't matter for the specific code in this extension, but most projects I've worked on prefer `===` for consistency.

Would you consider adding a linter to the project?